### PR TITLE
New configuration options: skipuncounted, clickable

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -71,6 +71,8 @@
               <li>darktheme</li>
               <li>color</li>
               <li>oppositecolor</li>
+              <li>skipuncounted</li>
+              <li>clickable</li>
             </ol>
           </section>
           <section class="center">
@@ -98,7 +100,7 @@
             <p class="small">For a light theme, the Verticator colors will be red on <em>all</em> normal slides and (still) white on slides that are set to a dark background with attributes.</p>
           </section>
           <section class="center">
-            <h4>Option 2: oppositecolor</h4>
+            <h4>Option 3: oppositecolor</h4>
             <p>You can set the opposite color of the Verticator bullets to a specific color. These apply if a slide has an opposite color to the main background of the theme.</p>
             <pre><code>Reveal.initialize({
 	...
@@ -108,6 +110,28 @@
 	plugins: [ Verticator ]
 </code></pre>
             <p class="small">For a light theme, the Verticator colors will (still) be black on normal slides and yellow on slides that are set to a dark background with attributes.</p>
+          </section>
+          <section class="center" data-visibility="uncounted">
+            <h4>Option 4: skipuncounted</h4>
+            <p>Slides that are marked with Reveal.js' 4.0 <kbd>data-visibility=&quot;uncounted&quot;</kbd>-Property can be skipped (like this slide, disabled by default)</p>
+            <pre><code>Reveal.initialize({
+	...
+	verticator: {
+		skipuncounted: true
+	},
+	plugins: [ Verticator ]
+</code></pre>
+          </section>
+          <section class="center">
+            <h4>Option 5: clickable</h4>
+            <p>Clicking on a a Verticator bullet jumps to to the corresponding page. This behaviour is enabled by default but can be disabled.</p>
+            <pre><code>Reveal.initialize({
+	...
+	verticator: {
+		clickable: false
+	},
+	plugins: [ Verticator ]
+</code></pre>
           </section>
           <section class="center">
             <h4>Option demos</h4>
@@ -133,7 +157,10 @@
     <script src="plugin/verticator/verticator.js"></script>
     <script>
       Reveal.initialize({
-      	transition: 'convex',
+        transition: 'convex',
+        verticator: {
+            // skipuncounted: true
+        },
       	plugins: [ Verticator ]
       });
     </script>

--- a/plugin/verticator/verticator.esm.js
+++ b/plugin/verticator/verticator.esm.js
@@ -97,23 +97,29 @@ var Plugin = function Plugin() {
 
     var activateBullet = function activateBullet(event) {
       var listItems = selectionArray(theVerticator, 'li');
-      listItems.filter(function (listItem, i) {
-        if (i == event.indexv) {
-          listItem.classList.add(activeclass);
-        } else {
-          listItem.classList.remove(activeclass);
+      var bestMatch = -1;
+      listItems.forEach(function (listItem, i) {
+        if (parseInt(listItem.getAttribute("data-index")) <= event.indexv) {
+          bestMatch = i;
         }
+
+        listItem.classList.remove(activeclass);
       });
+
+      if (bestMatch >= 0) {
+        listItems[bestMatch].classList.add(activeclass);
+      }
     };
 
-    var createBullets = function createBullets(event, sectionCount) {
+    var createBullets = function createBullets(event, sections) {
       theVerticator.classList.remove('visible');
       var listHtml = '';
 
-      for (var i = 0; i < sectionCount; i++) {
-        var link = event.indexh + "/" + i;
-        listHtml += '<li><a href="#/' + link + '"></li>';
-      }
+      sections.forEach(function(i) {
+        var link = ' href="#/' + event.indexh + "/" + i + '"';
+        listHtml += '<li data-index="' + i + '"><a ' +
+          (options.clickable ? link : '') + '></li>';
+      });
 
       setTimeout(function () {
         theVerticator.innerHTML = listHtml;
@@ -159,21 +165,30 @@ var Plugin = function Plugin() {
     var slideAppear = function slideAppear(event) {
       var slide = event.currentSlide;
       var parent = slide.parentNode;
-      var sectionCount = Array.from(parent.children).filter(function (elem) {
-        return elem.tagName == 'SECTION';
-      }).length;
+      var sections = Array.from(parent.children)
+        .map(function(elem, index) {
+          return [index, elem];
+        })
+        .filter(function (indexedElem) {
+          return indexedElem[1].tagName == 'SECTION'
+            && (!options.skipuncounted
+              || indexedElem[1].getAttribute('data-visibility') !== 'uncounted')
+        })
+        .map(function (indexedElem) {
+          return indexedElem[0];
+        });
 
       if (!parent.classList.contains('stack')) {
         theVerticator.classList.remove('visible');
-      } else if (sectionCount > 1) {
+      } else if (sections.length > 1) {
         if (event.previousSlide) {
           var lastParent = event.previousSlide.parentNode;
 
           if (parent != lastParent) {
-            createBullets(event, sectionCount);
+            createBullets(event, sections);
           }
         } else {
-          createBullets(event, sectionCount);
+          createBullets(event, sections);
         }
 
         setTimeout(function () {
@@ -203,7 +218,9 @@ var Plugin = function Plugin() {
     var defaultOptions = {
       darktheme: false,
       color: '',
-      oppositecolor: ''
+      oppositecolor: '',
+      skipuncounted: false,
+      clickable: true
     };
 
     var defaults = function defaults(options, defaultOptions) {


### PR DESCRIPTION
Revealjs 4 has the ability to "hide" slides from the progressbar and the numbering (see the [documentation](https://revealjs.com/markup/#slide-visibility) for details). I use this for continuations in some presentations.

This PR would allow reveal.js-verticator to also honor these hidden slides.

It also adds the option to make the bullets not clickable (mostly useful if you share presentations with others).

Perhaps those changes are useful for more people than just me?