### PR TITLE
Allow autogenerate to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Reveal.initialize({
 		skipuncounted: false,
 		clickable: true,
 		position: 'right',
-		offset: '3vmin'
+		offset: '3vmin',
+        autogenerate: true
 	},
 	plugins: [ Verticator ]
 	// ... 
@@ -110,6 +111,7 @@ Reveal.initialize({
 * **`clickable`**: Allow navigation to a slide by clicking on the corresponding Verticator bullet. This behaviour is enabled by default.
 * **`position`**: Sets the position of Verticator in the presentation. Set to `right` by default, it can also be set to `left`.
 * **`offset`**: Sets the offset of Verticator from the edge (right or left, see 'position') of the screen. Set to `3vmin` by default, it can be set to any other valid CSS size and unit. 
+* **`autogenerate`**: Autogenerate a UL element with the class `verticator` if none is found. 
 
 ## Like it?
 

--- a/plugin/verticator/plugin-src.js
+++ b/plugin/verticator/plugin-src.js
@@ -55,9 +55,10 @@ const Plugin = () => {
 		let theVerticator = revealElement.querySelector('ul.verticator');
 
 		if (!theVerticator) {
+      if(!options.autogenerate) return
 			let ul = document.createElement('ul');
 			ul.className += "verticator";
-			revealElement.insertBefore(ul, revealElement.childNodes[0]); 
+			revealElement.insertBefore(ul, revealElement.childNodes[0]);
 			theVerticator = revealElement.querySelector('ul.verticator');
 		}
 
@@ -132,7 +133,7 @@ const Plugin = () => {
 
 		const createBullets = function (event, sections) {
 			theVerticator.classList.remove('visible');
-			
+
 			theVerticator.style.color = options.color;
 
 			let listHtml = '';
@@ -219,7 +220,8 @@ const Plugin = () => {
 			skipuncounted: false,
 			clickable: true,
 			position: 'right',
-			offset: '3vmin'
+      offset: '3vmin',
+      autogenerate: true
 		};
 
 

--- a/plugin/verticator/verticator.esm.js
+++ b/plugin/verticator/verticator.esm.js
@@ -1,16 +1,15 @@
-
 /*****************************************************************
  * @author: Martijn De Jongh (Martino), martijn.de.jongh@gmail.com
  * https://github.com/Martinomagnifico
  *
- * Verticator.js for Reveal.js 
+ * Verticator.js for Reveal.js
  * Version 1.0.9
- * 
- * @license 
+ *
+ * @license
  * MIT licensed
  *
  * Thanks to:
- *  - Hakim El Hattab, Reveal.js 
+ *  - Hakim El Hattab, Reveal.js
  ******************************************************************/
 
 
@@ -21,7 +20,7 @@ var Plugin = function Plugin() {
   } catch (t) {
     !function (t) {
       var e = /:scope(?![\w-])/gi,
-          r = u(t.querySelector);
+        r = u(t.querySelector);
 
       t.querySelector = function (t) {
         return r.apply(this, arguments);
@@ -67,7 +66,7 @@ var Plugin = function Plugin() {
 
   var getNodeindex = function getNodeindex(elm) {
     var c = elm.parentNode.children,
-        i = 0;
+      i = 0;
 
     for (; i < c.length; i++) {
       if (c[i] == elm) return i;
@@ -79,6 +78,7 @@ var Plugin = function Plugin() {
     var theVerticator = revealElement.querySelector('ul.verticator');
 
     if (!theVerticator) {
+      if (!options.autogenerate) return
       var ul = document.createElement('ul');
       ul.className += "verticator";
       revealElement.insertBefore(ul, revealElement.childNodes[0]);
@@ -222,7 +222,8 @@ var Plugin = function Plugin() {
       skipuncounted: false,
       clickable: true,
       position: 'right',
-      offset: '3vmin'
+      offset: '3vmin',
+      autogenerate: true
     };
 
     var defaults = function defaults(options, defaultOptions) {

--- a/plugin/verticator/verticator.js
+++ b/plugin/verticator/verticator.js
@@ -3,15 +3,16 @@
  * @author: Martijn De Jongh (Martino), martijn.de.jongh@gmail.com
  * https://github.com/Martinomagnifico
  *
- * Verticator.js for Reveal.js 
+ * Verticator.js for Reveal.js
  * Version 1.0.9
- * 
- * @license 
+ *
+ * @license
  * MIT licensed
  *
  * Thanks to:
- *  - Hakim El Hattab, Reveal.js 
+ *  - Hakim El Hattab, Reveal.js
  ******************************************************************/
+
 
 
 (function (global, factory) {
@@ -228,7 +229,8 @@
 	      skipuncounted: false,
 	      clickable: true,
 	      position: 'right',
-	      offset: '3vmin'
+	      offset: '3vmin',
+        autogenerate: true
 	    };
 
 	    var defaults = function defaults(options, defaultOptions) {


### PR DESCRIPTION
Thanks for this plugin it works great.

I have a couple of reveal presentations that get rendered by the backend of a server and I would like to add verticator for some of them but not all (some are very long lists ...).

So I added an option in the `plugin-src.js` : `autogenerate`. It is set to `true` by default, when it gets set to false, if there is no `ul` element with the `verticator` class the `verticate()` function will return.

I don't know if this can be usefull to others but I would like to share it;